### PR TITLE
Deploy a specific release channel

### DIFF
--- a/aws/eks/README.md
+++ b/aws/eks/README.md
@@ -91,6 +91,22 @@ cd helpers
 ./write_kubeconfig $clusername $region
 ```
 
+## Access Konveyor UI
+1. export KUBECONFIG=`pwd`/{REPLACE_MYNAME}.kubeconfig
+   * Look at your `my_override_vars.yml` and see the name you chose for ```myname```
+1. Leverage the ALB Ingress automatically created by the konveyor operator: ```ui_ingress_class_name: "alb"```
+   * ```kubectl get ingress -n konveyor-tackle```
+      * You could also run a local port-forward if you saw an issue with the Ingress
+         * ```kubectl port-forward svc/tackle-ui 7080:8080 -n konveyor-tackle```
+         * Then open browser to http://localhost:7080
+1. Default login info for first time logging in is defined in https://github.com/konveyor/tackle2-hub/blob/main/auth/users.yaml#L2
+   * Username: ```admin```
+   * Password: ```Passw0rd!```
+1. After successful login it will prompt for a new password for ```admin``` 
+
+## Getting Started with an Analysis
+1. Follow an example here:  https://github.com/konveyor/example-applications/blob/main/example-1/README.md
+
 # Amazon EKS Documentation
 Below may help us as we run into problems or need to learn more on the environment specifics 
 * [Amazon Elastic Kubernetes Service Documentation](https://docs.aws.amazon.com/eks/index.html)

--- a/roles/konveyor/defaults/main.yml
+++ b/roles/konveyor/defaults/main.yml
@@ -1,2 +1,15 @@
 ---
 # defaults file for konveyor
+konveyor_namespace: konveyor-tackle
+
+# Setting to True will skip the use of konveyor_operator_channel and use a custom CatalogSource instead
+konveyor_install_unstable_builds: False
+
+# Operator channels:  
+# alpha - Test releases, not recommended
+# konveyor-0.1 - Latest stable release in the 0.1.z series
+konveyor_operator_channel: konveyor-0.1 
+
+rwx_supported: False
+feature_auth_required: True
+ui_ingress_class_name: "alb"

--- a/roles/konveyor/tasks/main.yml
+++ b/roles/konveyor/tasks/main.yml
@@ -1,22 +1,78 @@
 ---
 # tasks file for konveyor
-- name: Creates directory
-  file:
-    path: "{{ tmp_dir }}"
-    state: directory
-    mode: 0775
-
-- name: Download konveyor/tackle2-operator/main/tackle-k8s.yaml 
-  ansible.builtin.get_url:
-    url: https://raw.githubusercontent.com/konveyor/tackle2-operator/main/tackle-k8s.yaml
-    dest: "{{ tmp_dir }}/tackle-k8s.yaml"
-    mode: '0664'
-
-- name: Apply tackle-k8s.yaml to the cluster.
+- name: Create namespace - {{ konveyor_namespace }}
   kubernetes.core.k8s:
-    state: present
-    src: "{{ tmp_dir }}/tackle-k8s.yaml"
     kubeconfig: "{{ kubeconfig }}"
+    definition: 
+      apiVersion: v1
+      kind: Namespace
+      metadata:
+        name: "{{ konveyor_namespace }}"
+
+- name: Create OperatorGroup
+  kubernetes.core.k8s:
+    kubeconfig: "{{ kubeconfig }}"
+    definition: 
+      apiVersion: operators.coreos.com/v1
+      kind: OperatorGroup
+      metadata:
+        name: operatorgroup
+        namespace: "{{ konveyor_namespace }}"
+      spec:
+        targetNamespaces:
+        - "{{ konveyor_namespace }}"
+
+# If we want to install :latest we need to define our own CatalogSource   
+- name: Custom block for unreleased images 
+  block:
+    - name: Create CustomCatalogSource to deploy unstable bleeding edge unreleased images that track 'main' since 'konveyor_install_unstable_builds' is {{ konveyor_install_unstable_builds }}
+      kubernetes.core.k8s:
+        kubeconfig: "{{ kubeconfig }}"
+        definition: 
+          apiVersion: operators.coreos.com/v1alpha1
+          kind: CatalogSource
+          metadata:
+            name: konveyor
+            namespace: "{{ konveyor_namespace }}"
+          spec:
+            displayName: Konveyor Operator
+            publisher: Konveyor
+            sourceType: grpc
+            image: quay.io/konveyor/tackle2-operator-index:latest
+
+    - name: Create Subscription to our custom CatalogSource
+      kubernetes.core.k8s:
+        kubeconfig: "{{ kubeconfig }}"
+        definition:
+          apiVersion: operators.coreos.com/v1alpha1
+          kind: Subscription
+          metadata:
+            name: konveyor-operator
+            namespace: "{{ konveyor_namespace }}"
+          spec:
+            channel: development
+            installPlanApproval: Automatic
+            name: konveyor-operator
+            source: konveyor
+            sourceNamespace: "{{ konveyor_namespace }}"
+  when: konveyor_install_unstable_builds|bool
+
+# Assuming we did not create a custom CatalogSource above, we create a Subscription against a published channel in community-operators
+- name: Create Subscription to konveyor-operator published in channel "{{ konveyor_operator_channel }}" in community-operators since konveyor_install_unstable_builds is {{ konveyor_install_unstable_builds }}
+  kubernetes.core.k8s:
+    kubeconfig: "{{ kubeconfig }}"
+    definition:        
+      apiVersion: operators.coreos.com/v1alpha1
+      kind: Subscription
+      metadata:
+        name: my-konveyor-operator
+        namespace: "{{ konveyor_namespace }}"
+      spec:
+        channel: "{{ konveyor_operator_channel }}"
+        name: konveyor-operator
+        source: operatorhubio-catalog
+        sourceNamespace: olm
+  when: not konveyor_install_unstable_builds|bool
 
 - name: Wait for Tackle CRD to be established
   kubernetes.core.k8s:
@@ -45,9 +101,9 @@
       kind: Tackle
       metadata:
         name: "tackle"
-        namespace: konveyor-tackle 
+        namespace: "{{ konveyor_namespace }}" 
       spec:
-        rwx_supported: "false"
-        feature_auth_required: "true"
-        ui_ingress_class_name: "alb"
+        rwx_supported: "{{ rwx_supported }}"
+        feature_auth_required: "{{ feature_auth_required }}"
+        ui_ingress_class_name: "{{ ui_ingress_class_name }}"
     state: present


### PR DESCRIPTION
Tested with success on EKS with ALB Ingress and auth enabled for:
 - alpha (release-0.2.0-alpha)
 - konveyor-0.1 (release-0.1.2)
 - :latest with a custom catalog source using: quay.io/konveyor/tackle2-operator-index:latest